### PR TITLE
Fix CLI execution and improve usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,23 +8,42 @@ This project provides a small command line interface built with [oclif](https://
 npm install -g ./
 ```
 
+From a cloned repository you can invoke the CLI without installing it globally:
+
+```bash
+node ./bin/run --help
+```
+
 ## Usage
 
-Place the AEM SDK ZIP files in a directory and run the command:
+Place the AEM SDK ZIP files in a directory and run the command from that
+directory. At a minimum the CLI expects an `aem-sdk-*.zip` archive. Optional
+archives such as `aem-forms-addon-*.zip` or the dispatcher tools installer can
+be placed next to it. The tool extracts everything into an `instance/` folder.
 
 ```bash
 aem-sdk-setup
 ```
 
-You will be asked which optional components (AEM Forms, secrets and Dispatcher tools) you would like to install.
+The command walks you through an interactive setup where you choose whether to
+install AEM Forms, secrets or the Dispatcher tools. The archives are extracted
+into an `instance/` folder and start scripts are copied for you.
+
+If the ZIP files reside elsewhere you can provide the location using the `-d`
+or `--directory` flag:
+
+```bash
+aem-sdk-setup --directory /path/to/zips
+```
 
 ### Commands
 
 The CLI exposes a single root command. The following options are available:
 
 ```bash
-aem-sdk-setup --help       # display usage information
-aem-sdk-setup --version    # display version number
+aem-sdk-setup --help                   # display usage information
+aem-sdk-setup --version                # display version number
+aem-sdk-setup -d /path/to/zips         # use files from a different directory
 ```
 
 ## Contribution

--- a/bin/run
+++ b/bin/run
@@ -1,3 +1,5 @@
 #!/usr/bin/env node
-const { run } = require('@oclif/core');
-run().catch(require('@oclif/core/handle')); 
+// Execute the CLI entry point. The src/index.js file configures oclif and
+// handles all command execution. Requiring it here ensures the CLI works when
+// installed globally via the `bin` field in package.json.
+require('../src');

--- a/oclif.config.json
+++ b/oclif.config.json
@@ -1,0 +1,8 @@
+{
+  "name": "aem-sdk-setup",
+  "version": "1.0.0",
+  "bin": "aem-sdk-setup",
+  "oclif": {
+    "commands": { "strategy": "single", "target": "commands/setup.js" }
+  }
+}

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -4,7 +4,7 @@ const glob = require('glob');
 const unzipper = require('unzipper');
 const readline = require('node:readline/promises');
 const { stdin: input, stdout: output } = require('node:process');
-const { Command } = require('@oclif/core');
+const { Command, Flags } = require('@oclif/core');
 
 /**
  * Root command for setting up an AEM SDK environment.
@@ -15,218 +15,239 @@ const { Command } = require('@oclif/core');
  */
 module.exports = class Setup extends Command {
   static description = 'Set up AEM SDK environment';
+  static flags = {
+    directory: Flags.string({
+      char: 'd',
+      description: 'Directory containing the AEM SDK files',
+      default: '.',
+    }),
+  };
 
   /**
    * Execute the setup process. Prompts the user for desired components and
    * performs extraction and configuration steps.
    */
   async run() {
-    const SDK_PREFIX = 'aem-sdk-';
-    const FORMS_PREFIX = 'aem-forms-addon-';
-    const DISPATCHER_PREFIX = 'aem-sdk-dispatcher-tools-';
-    const AUTHOR_PORT = 4502;
-    const PUBLISH_PORT = 4503;
-
-    const sdkZip = glob.sync(`${SDK_PREFIX}*.zip`)[0];
-    if (!sdkZip) {
-      this.error(
-        `Error: AEM SDK file (${SDK_PREFIX}*.zip) not found in the current directory.`,
-      );
+    const { flags } = await this.parse(Setup);
+    const targetDir = path.resolve(flags.directory);
+    if (!(await fs.pathExists(targetDir))) {
+      this.error(`Directory not found: ${targetDir}`);
     }
+    const originalDir = process.cwd();
+    process.chdir(targetDir);
+    try {
+      const SDK_PREFIX = 'aem-sdk-';
+      const FORMS_PREFIX = 'aem-forms-addon-';
+      const DISPATCHER_PREFIX = 'aem-sdk-dispatcher-tools-';
+      const AUTHOR_PORT = 4502;
+      const PUBLISH_PORT = 4503;
 
-    this.log(`Extracting AEM SDK file: ${sdkZip}`);
-    const extractedDir = path.join(
-      process.cwd(),
-      path.basename(sdkZip, '.zip'),
-    );
-    await fs
-      .createReadStream(sdkZip)
-      .pipe(unzipper.Extract({ path: extractedDir }))
-      .promise();
-
-    await fs.ensureDir('instance/author/crx-quickstart/install');
-    await fs.ensureDir('instance/publish/crx-quickstart/install');
-
-    const jarPattern = `${SDK_PREFIX}quickstart-*.jar`;
-    const jar = glob.sync(jarPattern, { cwd: extractedDir })[0];
-    if (!jar) {
-      this.error(
-        `Error: Quickstart jar (${jarPattern}) not found in ${extractedDir}`,
-      );
-    }
-    await fs.copy(
-      path.join(extractedDir, jar),
-      `instance/author/aem-author-p${AUTHOR_PORT}.jar`,
-    );
-    await fs.copy(
-      path.join(extractedDir, jar),
-      `instance/publish/aem-publish-p${PUBLISH_PORT}.jar`,
-    );
-
-    if (await fs.pathExists('install')) {
-      this.log(
-        "Copying ZIP files from 'install' to 'instance/author/crx-quickstart/install'...",
-      );
-      for (const file of glob.sync('*.zip', { cwd: 'install' })) {
-        await fs.copy(
-          path.join('install', file),
-          path.join('instance/author/crx-quickstart/install', file),
-        );
-        await fs.copy(
-          path.join('install', file),
-          path.join('instance/publish/crx-quickstart/install', file),
-        );
-      }
-    } else {
-      this.warn("Warning: 'install' folder not found. No ZIP files copied.");
-    }
-
-    const rl = readline.createInterface({ input, output });
-    const fullInstall = (
-      await rl.question('Do you want a full installation? (yes/no): ')
-    ).trim();
-    let installForms, installSecrets, installDispatcher;
-    if (fullInstall === 'yes') {
-      installForms = 'yes';
-      installSecrets = 'yes';
-      installDispatcher = 'yes';
-    } else {
-      installForms = (
-        await rl.question('Do you want to install AEM Forms? (yes/no): ')
-      ).trim();
-      installSecrets = (
-        await rl.question('Do you want to install secrets? (yes/no): ')
-      ).trim();
-      installDispatcher = (
-        await rl.question('Do you want to install AEM Dispatcher? (yes/no): ')
-      ).trim();
-    }
-    rl.close();
-
-    if (installForms === 'yes') {
-      const formsZip = glob.sync(`${FORMS_PREFIX}*.zip`)[0];
-      if (!formsZip) {
+      const sdkZip = glob.sync(`${SDK_PREFIX}*.zip`)[0];
+      if (!sdkZip) {
         this.error(
-          `Error: AEM Forms addons ZIP file (${FORMS_PREFIX}*.zip) not found in the current directory.`,
+          `Error: AEM SDK file (${SDK_PREFIX}*.zip) not found in the current directory.`,
         );
       }
-      this.log(`Extracting AEM Forms addons ZIP file: ${formsZip}`);
-      const formsDir = path.join(
+
+      this.log(`Extracting AEM SDK file: ${sdkZip}`);
+      const extractedDir = path.join(
         process.cwd(),
-        path.basename(formsZip, '.zip'),
+        path.basename(sdkZip, '.zip'),
       );
       await fs
-        .createReadStream(formsZip)
-        .pipe(unzipper.Extract({ path: formsDir }))
+        .createReadStream(sdkZip)
+        .pipe(unzipper.Extract({ path: extractedDir }))
         .promise();
-      const formsFar = glob.sync('*.far', { cwd: formsDir, absolute: true })[0];
-      if (!formsFar) {
+
+      await fs.ensureDir('instance/author/crx-quickstart/install');
+      await fs.ensureDir('instance/publish/crx-quickstart/install');
+
+      const jarPattern = `${SDK_PREFIX}quickstart-*.jar`;
+      const jar = glob.sync(jarPattern, { cwd: extractedDir })[0];
+      if (!jar) {
         this.error(
-          'Error: AEM Forms Archive (.far) file not found within extracted directory.',
+          `Error: Quickstart jar (${jarPattern}) not found in ${extractedDir}`,
         );
       }
       await fs.copy(
-        formsFar,
-        path.join(
-          'instance/author/crx-quickstart/install',
-          path.basename(formsFar),
-        ),
+        path.join(extractedDir, jar),
+        `instance/author/aem-author-p${AUTHOR_PORT}.jar`,
       );
       await fs.copy(
-        formsFar,
-        path.join(
-          'instance/publish/crx-quickstart/install',
-          path.basename(formsFar),
-        ),
+        path.join(extractedDir, jar),
+        `instance/publish/aem-publish-p${PUBLISH_PORT}.jar`,
       );
-    } else {
-      this.log('Skipping AEM Forms installation.');
-    }
 
-    if (installSecrets === 'yes') {
-      this.log('Installing secrets...');
-      await fs.ensureDir('instance/author/crx-quickstart/conf');
-      await fs.writeFile(
-        'instance/author/crx-quickstart/conf/sling.properties',
-        'org.apache.felix.configadmin.plugin.interpolation.secretsdir=${sling.home}/secretsdir',
-      );
-      await fs.ensureDir('instance/publish/crx-quickstart/conf');
-      await fs.writeFile(
-        'instance/publish/crx-quickstart/conf/sling.properties',
-        'org.apache.felix.configadmin.plugin.interpolation.secretsdir=${sling.home}/secretsdir',
-      );
-      if (await fs.pathExists('secretsdir')) {
+      if (await fs.pathExists('install')) {
+        this.log(
+          "Copying ZIP files from 'install' to 'instance/author/crx-quickstart/install'...",
+        );
+        for (const file of glob.sync('*.zip', { cwd: 'install' })) {
+          await fs.copy(
+            path.join('install', file),
+            path.join('instance/author/crx-quickstart/install', file),
+          );
+          await fs.copy(
+            path.join('install', file),
+            path.join('instance/publish/crx-quickstart/install', file),
+          );
+        }
+      } else {
+        this.warn("Warning: 'install' folder not found. No ZIP files copied.");
+      }
+
+      const rl = readline.createInterface({ input, output });
+      const fullInstall = (
+        await rl.question('Do you want a full installation? (yes/no): ')
+      ).trim();
+      let installForms, installSecrets, installDispatcher;
+      if (fullInstall === 'yes') {
+        installForms = 'yes';
+        installSecrets = 'yes';
+        installDispatcher = 'yes';
+      } else {
+        installForms = (
+          await rl.question('Do you want to install AEM Forms? (yes/no): ')
+        ).trim();
+        installSecrets = (
+          await rl.question('Do you want to install secrets? (yes/no): ')
+        ).trim();
+        installDispatcher = (
+          await rl.question('Do you want to install AEM Dispatcher? (yes/no): ')
+        ).trim();
+      }
+      rl.close();
+
+      if (installForms === 'yes') {
+        const formsZip = glob.sync(`${FORMS_PREFIX}*.zip`)[0];
+        if (!formsZip) {
+          this.error(
+            `Error: AEM Forms addons ZIP file (${FORMS_PREFIX}*.zip) not found in the current directory.`,
+          );
+        }
+        this.log(`Extracting AEM Forms addons ZIP file: ${formsZip}`);
+        const formsDir = path.join(
+          process.cwd(),
+          path.basename(formsZip, '.zip'),
+        );
+        await fs
+          .createReadStream(formsZip)
+          .pipe(unzipper.Extract({ path: formsDir }))
+          .promise();
+        const formsFar = glob.sync('*.far', {
+          cwd: formsDir,
+          absolute: true,
+        })[0];
+        if (!formsFar) {
+          this.error(
+            'Error: AEM Forms Archive (.far) file not found within extracted directory.',
+          );
+        }
         await fs.copy(
-          'secretsdir',
-          'instance/author/crx-quickstart/secretsdir',
+          formsFar,
+          path.join(
+            'instance/author/crx-quickstart/install',
+            path.basename(formsFar),
+          ),
         );
         await fs.copy(
-          'secretsdir',
-          'instance/publish/crx-quickstart/secretsdir',
+          formsFar,
+          path.join(
+            'instance/publish/crx-quickstart/install',
+            path.basename(formsFar),
+          ),
         );
       } else {
-        this.warn(
-          "Warning: 'secretsdir' folder not found. Secrets not installed.",
-        );
+        this.log('Skipping AEM Forms installation.');
       }
-    } else {
-      this.log('Skipping secrets installation.');
-    }
 
-    if (installDispatcher === 'yes') {
-      const installer = glob.sync(`${DISPATCHER_PREFIX}*.sh`, {
-        cwd: extractedDir,
-      })[0];
-      if (!installer) {
-        this.error(
-          `Error: AEM Dispatcher installer script (${DISPATCHER_PREFIX}*.sh) not found in the extracted AEM SDK directory.`,
+      if (installSecrets === 'yes') {
+        this.log('Installing secrets...');
+        await fs.ensureDir('instance/author/crx-quickstart/conf');
+        await fs.writeFile(
+          'instance/author/crx-quickstart/conf/sling.properties',
+          'org.apache.felix.configadmin.plugin.interpolation.secretsdir=${sling.home}/secretsdir',
         );
+        await fs.ensureDir('instance/publish/crx-quickstart/conf');
+        await fs.writeFile(
+          'instance/publish/crx-quickstart/conf/sling.properties',
+          'org.apache.felix.configadmin.plugin.interpolation.secretsdir=${sling.home}/secretsdir',
+        );
+        if (await fs.pathExists('secretsdir')) {
+          await fs.copy(
+            'secretsdir',
+            'instance/author/crx-quickstart/secretsdir',
+          );
+          await fs.copy(
+            'secretsdir',
+            'instance/publish/crx-quickstart/secretsdir',
+          );
+        } else {
+          this.warn(
+            "Warning: 'secretsdir' folder not found. Secrets not installed.",
+          );
+        }
+      } else {
+        this.log('Skipping secrets installation.');
       }
-      await fs.chmod(path.join(extractedDir, installer), 0o755);
-      this.log(`Running AEM Dispatcher installer: ./${installer}`);
-      await new Promise((resolve, reject) => {
-        const child = require('child_process').spawn(`./${installer}`, {
+
+      if (installDispatcher === 'yes') {
+        const installer = glob.sync(`${DISPATCHER_PREFIX}*.sh`, {
           cwd: extractedDir,
-          stdio: 'inherit',
-          shell: true,
+        })[0];
+        if (!installer) {
+          this.error(
+            `Error: AEM Dispatcher installer script (${DISPATCHER_PREFIX}*.sh) not found in the extracted AEM SDK directory.`,
+          );
+        }
+        await fs.chmod(path.join(extractedDir, installer), 0o755);
+        this.log(`Running AEM Dispatcher installer: ./${installer}`);
+        await new Promise((resolve, reject) => {
+          const child = require('child_process').spawn(`./${installer}`, {
+            cwd: extractedDir,
+            stdio: 'inherit',
+            shell: true,
+          });
+          child.on('close', (code) =>
+            code === 0
+              ? resolve()
+              : reject(
+                  new Error(`dispatcher installer exited with code ${code}`),
+                ),
+          );
         });
-        child.on('close', (code) =>
-          code === 0
-            ? resolve()
-            : reject(
-                new Error(`dispatcher installer exited with code ${code}`),
-              ),
+        const dispatcherDir = glob.sync('dispatcher-sdk-*', {
+          cwd: extractedDir,
+          absolute: true,
+        })[0];
+        if (!dispatcherDir) {
+          this.error(
+            'Error: AEM Dispatcher configuration directory (dispatcher-sdk-*) not found.',
+          );
+        }
+        await fs.move(dispatcherDir, 'dispatcher', { overwrite: true });
+        this.log(
+          `AEM Dispatcher configuration directory '${path.basename(dispatcherDir)}' renamed and moved to 'dispatcher'.`,
         );
-      });
-      const dispatcherDir = glob.sync('dispatcher-sdk-*', {
-        cwd: extractedDir,
-        absolute: true,
-      })[0];
-      if (!dispatcherDir) {
-        this.error(
-          'Error: AEM Dispatcher configuration directory (dispatcher-sdk-*) not found.',
-        );
-      }
-      await fs.move(dispatcherDir, 'dispatcher', { overwrite: true });
-      this.log(
-        `AEM Dispatcher configuration directory '${path.basename(dispatcherDir)}' renamed and moved to 'dispatcher'.`,
-      );
-    } else {
-      this.log('Skipping AEM Dispatcher installation.');
-    }
-
-    for (const scriptName of ['start_author.sh', 'start_publish.sh']) {
-      if (await fs.pathExists(scriptName)) {
-        const dest = `instance/${scriptName.includes('author') ? 'author' : 'publish'}/${scriptName}`;
-        await fs.copy(scriptName, dest);
-        this.log(`Copying '${scriptName}' to '${path.dirname(dest)}/'...`);
       } else {
-        this.warn(
-          `Warning: '${scriptName}' not found. Cannot copy to '${scriptName.includes('author') ? 'instance/author/' : 'instance/publish/'}'.`,
-        );
+        this.log('Skipping AEM Dispatcher installation.');
       }
-    }
 
-    this.log('AEM setup completed successfully.');
+      for (const scriptName of ['start_author.sh', 'start_publish.sh']) {
+        if (await fs.pathExists(scriptName)) {
+          const dest = `instance/${scriptName.includes('author') ? 'author' : 'publish'}/${scriptName}`;
+          await fs.copy(scriptName, dest);
+          this.log(`Copying '${scriptName}' to '${path.dirname(dest)}/'...`);
+        } else {
+          this.warn(
+            `Warning: '${scriptName}' not found. Cannot copy to '${scriptName.includes('author') ? 'instance/author/' : 'instance/publish/'}'.`,
+          );
+        }
+      }
+
+      this.log('AEM setup completed successfully.');
+    } finally {
+      process.chdir(originalDir);
+    }
   }
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,10 @@
+const path = require('path');
 const { run, flush, handle } = require('@oclif/core');
+const pjson = require('../oclif.config.json');
 
 run(undefined, {
-  root: __dirname,
-  pjson: {
-    name: 'aem-sdk-setup',
-    version: '1.0.0',
-    bin: 'aem-sdk-setup',
-    oclif: {
-      commands: { strategy: 'single', target: 'src/commands/setup.js' },
-    },
-  },
+  root: path.join(__dirname, '..'),
+  pjson,
 })
   .then(flush)
   .catch(handle);

--- a/test/setup.test.js
+++ b/test/setup.test.js
@@ -16,6 +16,7 @@ describe('setup command', () => {
 
   test('fails when SDK zip is missing', async () => {
     glob.sync.mockReturnValueOnce([]);
+    fs.pathExists.mockResolvedValue(true);
     await expect(Setup.run([], ROOT_OPTS)).rejects.toThrow('AEM SDK file');
   });
 
@@ -29,7 +30,7 @@ describe('setup command', () => {
     });
     fs.ensureDir.mockResolvedValue();
     fs.copy.mockResolvedValue();
-    fs.pathExists.mockResolvedValue(false);
+    fs.pathExists.mockResolvedValueOnce(true).mockResolvedValue(false);
     const readline = require('node:readline/promises');
     jest.spyOn(readline, 'createInterface').mockReturnValue({
       question: jest


### PR DESCRIPTION
## Summary
- hook up bin entry to invoke src correctly
- allow passing AEM SDK location with `--directory` flag
- document how to run the CLI
- update tests for new flag
- add separate `oclif.config.json` and load it in CLI

## Testing
- `npm install`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6848854d32b4832fbdfe3486fd51a0b5