### PR TITLE
Fix deprecated artifact action

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -24,7 +24,7 @@ jobs:
         shell: bash
       - run: npm test -- --coverage
         shell: bash
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: coverage-${{ matrix.os }}
           path: coverage

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AEM SDK Setup CLI
 
-![CI](https://github.com/org/aem-sdk-setup/actions/workflows/node.yml/badge.svg)
+![CI](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml/badge.svg)
 
 This project provides a small command line interface built with [oclif](https://oclif.io/) to automate setting up a local AEM SDK. It is **not** a migration tool but simply a helper utility for extracting the SDK archives and preparing your development environment.
 

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/org/aem-sdk-setup.git"
+    "url": "https://github.com/AEM-X/aem-sdk-setup.git"
   },
   "bugs": {
-    "url": "https://github.com/org/aem-sdk-setup/issues"
+    "url": "https://github.com/AEM-X/aem-sdk-setup/issues"
   },
-  "homepage": "https://github.com/org/aem-sdk-setup#readme",
+  "homepage": "https://github.com/AEM-X/aem-sdk-setup#readme",
   "files": [
     "bin",
     "src",


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to use `actions/upload-artifact@v4`
- fix README CI badge and related URLs to point to `AEM-X/aem-sdk-setup`

## Testing
- `npm ci`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6848a62d4e04832fa507d034be9a4f6f