### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -10,6 +10,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         node: [18.x, 20.x]
@@ -24,9 +25,9 @@ jobs:
         shell: bash
       - run: npm run lint
         shell: bash
-      - run: npm test -- --coverage
+      - run: npm test -- --coverage --coverageReporters=text
         shell: bash
-      - uses: actions/upload-artifact@v4
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          name: coverage-${{ matrix.os }}
-          path: coverage
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -99,14 +99,13 @@ After publishing, the new version will be shown when running `aem-sdk-setup --ve
 
 ## Code Coverage
 
-The `node.yml` workflow runs `npm test -- --coverage` on every commit. The
-generated `coverage/` directory is uploaded as a workflow artifact so the
-results can be downloaded from the GitHub Actions page.
+The `node.yml` workflow runs `npm test -- --coverage --coverageReporters=text` on every commit. The coverage
+results are printed in the console and uploaded to Codecov.
 
 To check coverage locally run:
 
 ```bash
-npm test -- --coverage
+npm test -- --coverage --coverageReporters=text
 ```
 
 The current test suite reports around **97%** statement coverage.


### PR DESCRIPTION
## Summary
- remove artifact upload
- show coverage in console
- keep matrix jobs running even if one fails
- upload coverage to Codecov

## Testing
- `npm ci`
- `npm test -- --coverage --coverageReporters=text`


------
https://chatgpt.com/codex/tasks/task_e_6848af933230832fa4ef77957dc9da05