### PR TITLE
Add Codecov and quality badges with license scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,24 @@
+name: License Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - run: npm ci
+      - name: Generate license report
+        run: npx license-checker --summary --production > license-summary.txt
+      - name: Upload license report
+        uses: actions/upload-artifact@v4
+        with:
+          name: license-summary
+          path: license-summary.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # AEM SDK Setup CLI
 
-![CI](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml/badge.svg)
+[![CI](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml)
+[![Coverage Status](https://codecov.io/gh/AEM-X/aem-sdk-setup/branch/main/graph/badge.svg)](https://codecov.io/gh/AEM-X/aem-sdk-setup)
+[![CodeQL](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/codeql.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/codeql.yml)
+[![License Scan](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml)
 
 This project provides a small command line interface built with [oclif](https://oclif.io/) to automate setting up a local AEM SDK. It is **not** a migration tool but simply a helper utility for extracting the SDK archives and preparing your development environment.
 
@@ -87,7 +90,7 @@ After publishing, the new version will be shown when running `aem-sdk-setup --ve
 - `fs-extra`, `glob` and `unzipper` for filesystem and archive operations
 - Jest for unit testing with coverage
 - ESLint and Prettier for code style
-- GitHub Actions for continuous integration with linting, formatting checks and tests
+- GitHub Actions for continuous integration with linting, formatting checks, tests and CodeQL analysis
 
 ## Package Information
 
@@ -109,6 +112,17 @@ npm test -- --coverage --coverageReporters=text
 ```
 
 The current test suite reports around **97%** statement coverage.
+
+## Code Quality
+
+In addition to coverage reports, the repository runs a scheduled CodeQL scan via
+GitHub Actions to detect common vulnerabilities and ensure code quality.
+
+## License Scan
+
+A dedicated workflow uses `license-checker` to review dependency licenses on
+every push and pull request. The generated report is uploaded as a workflow
+artifact for further inspection.
 
 ## Supported Environments
 


### PR DESCRIPTION
## Summary
- add badges for CI, Codecov, CodeQL, and license scan to README
- document license scanning
- create GitHub Actions workflow to generate a license report using `license-checker`

## Testing
- `npm ci`
- `npm test --silent`
- `npx eslint . --max-warnings 0`
- `npx prettier --check "**/*.{js,json,md}"`


------
https://chatgpt.com/codex/tasks/task_e_6848b1fbb960832fb27cb24151368224