### PR TITLE
Fix Codecov upload by generating lcov reports

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
       - run: npm run lint
         shell: bash
-      - run: npm test -- --coverage --coverageReporters=text
+      - run: npm test -- --coverage --coverageReporters=text --coverageReporters=lcov
         shell: bash
       - name: Upload coverage reports to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.node == '20.x'

--- a/README.md
+++ b/README.md
@@ -103,13 +103,13 @@ After publishing, the new version will be shown when running `aem-sdk-setup --ve
 
 ## Code Coverage
 
-The `node.yml` workflow runs `npm test -- --coverage --coverageReporters=text` on every commit. The coverage
+The `node.yml` workflow runs `npm test -- --coverage --coverageReporters=text --coverageReporters=lcov` on every commit. The coverage
 results are printed in the console and uploaded to Codecov.
 
 To check coverage locally run:
 
 ```bash
-npm test -- --coverage --coverageReporters=text
+npm test -- --coverage --coverageReporters=text --coverageReporters=lcov
 ```
 
 The current test suite reports around **97%** statement coverage.


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to produce lcov coverage
- document coverage command in README

## Testing
- `npm test -- --coverage --coverageReporters=text --coverageReporters=lcov`

------
https://chatgpt.com/codex/tasks/task_e_6848bd18dde8832f84d17e525103782e