### PR TITLE
Fix semantic release and publish to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,3 +19,4 @@ jobs:
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     [
       "@semantic-release/npm",
       {
-        "npmPublish": false
+        "npmPublish": true
       }
     ],
     [

--- a/README.md
+++ b/README.md
@@ -122,13 +122,12 @@ You can also run `aem-sdk-setup update` to upgrade to the latest release.
 
 ## Publishing
 
-The CLI reads its version from `package.json`. To release a new version:
+Releases are automated using [semantic-release](https://github.com/semantic-release/semantic-release).
+Whenever commits are pushed to `main`, the `Release` workflow creates a new GitHub
+release and publishes the package to npm.
 
-1. Bump the version with `npm version <patch|minor|major>`.
-2. Ensure the `author` field in `package.json` is populated.
-3. Publish the package to npm using `npm publish --access public`.
-
-After publishing, the new version will be shown when running `aem-sdk-setup --version`.
+Ensure a `NPM_TOKEN` secret with publish rights is configured for the repository
+so the workflow can upload the package.
 
 ## Tech Stack
 


### PR DESCRIPTION
## Summary
- enable npm publishing via semantic-release
- grant release workflow write permissions and add NPM token
- document automated publishing with semantic-release

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878f8331918832fabdfd282713a7ca7