### PR TITLE
Centralize constants and logging

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('./eslint.config.cjs');

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,1 +1,0 @@
-module.exports = require('./eslint.config.cjs');

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Generate JSDoc
+        run: npm run docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,10 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Generate JSDoc
+        if: success()
         run: npm run docs
       - name: Publish docs
+        if: success()
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,3 +26,8 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Generate JSDoc
         run: npm run docs
+      - name: Publish docs
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,49 @@
 # Repository Guidelines for Codex Agents
 
-- Use Prettier and ESLint configs provided in the repository.
-- Avoid synchronous fs operations and hard coded paths.
-- All CLI logs should be formatted using `src/utils/log.js`.
-- New code must be covered by Jest unit tests using mocked file systems.
-- Commands should remain compatible with oclif v4 and use CommonJS modules.
-- Always run `npm test` before committing.
+## Project Structure Rules
+
+- Commands parse flags only and delegate logic to modules in `src/lib/`.
+- Use `src/utils/log.js` for all CLI output and `src/lib/constants.js` for shared values.
+- Never use synchronous filesystem APIs or hard‑coded paths.
+
+## Required CLI Behavior
+
+- Each command must support `--dry-run`, `--verbose`, `--json`, `--force`, and `--skip-*` flags.
+- Show progress with `ux.action.start()` and `ux.action.stop()` when tasks take noticeable time.
+- Throw errors with `this.error()` for user-facing failures.
+
+## Testing Standards
+
+- Achieve 100% Jest coverage for new code.
+- Mock all filesystem or external interactions.
+- Cover success, failure, edge cases, and flag effects.
+
+## Documentation Standards
+
+- Document every exported function with JSDoc including purpose, `@param`, `@returns`, and error behavior.
+- Run `npm run docs` to generate HTML docs in the `docs/` folder.
+
+## Release and CI
+
+- Commits must follow semantic-release conventions; version numbers are managed automatically.
+- CI must pass lint, tests, and formatting before merge. Documentation is rebuilt on each release.
+
+## Codex Execution Rules (Every Time):
+
+Always read README.md, package.json, oclif.config.json before doing anything
+
+Only modify files related to the current phase or task
+
+Never repeat or reanalyze completed work
+
+Check for existing functionality before adding anything
+
+Reuse lib/ helpers when applicable
+
+Never leave TODOs or incomplete logic
+
+Prioritize performance, clarity, testability over cleverness
+
+## Contributor Reminder
+
+All contributors, human or AI, must maintain production-level standards. Commits must not reduce coverage, break CI, or bypass linting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository Guidelines for Codex Agents
+
+- Use Prettier and ESLint configs provided in the repository.
+- Avoid synchronous fs operations and hard coded paths.
+- All CLI logs should be formatted using `src/utils/log.js`.
+- New code must be covered by Jest unit tests using mocked file systems.
+- Commands should remain compatible with oclif v4 and use CommonJS modules.
+- Always run `npm test` before committing.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 [![License Scan](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml)
 [![Security Audit](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/npm-audit.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/npm-audit.yml)
 
-This project provides a small command line interface built with [oclif](https://oclif.io/) to automate setting up a local AEM SDK. It is **not** a migration tool but simply a helper utility for extracting the SDK archives and preparing your development environment.
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+AEM SDK Setup is a Node.js CLI built with [oclif](https://oclif.io/) that automates preparing local AEM SDK instances. It extracts the official archives and can set up dispatcher configs, forms add-ons, and secrets. The project uses Jest for testing, JSDoc for documentation, and semantic-release for automated versioning.
 
 <!-- toc -->
 
@@ -32,16 +33,21 @@ This project provides a small command line interface built with [oclif](https://
 Requires Node.js 18 or later.
 
 ```bash
-npm install -g ./
+npm install -g aem-sdk-setup
 ```
 
 Installing globally makes the `aem-sdk-setup` command available in your `PATH`.
 
-From a cloned repository you can invoke the CLI without installing it globally:
+Clone the repository and install dependencies for local development:
 
 ```bash
-node ./bin/run --help
+git clone https://github.com/AEM-X/aem-sdk-setup.git
+cd aem-sdk-setup
+npm install
+npm link
 ```
+
+Now you can run `aem-sdk-setup --help` from anywhere.
 
 ## Getting started
 
@@ -54,6 +60,16 @@ aem-sdk-setup init
 ```
 
 Place the ZIP files inside `setup/input` and run the CLI from anywhere.
+
+## Features
+
+- Extracts AEM SDK archives and copies quickstart JARs
+- Optional Forms add-on installation
+- Secrets folder handling
+- Dispatcher configuration setup
+- Dry-run and JSON output modes
+- Styled progress output
+- Generates API docs with JSDoc
 
 ## Usage
 
@@ -115,78 +131,57 @@ additional control.
 
 Running `aem-sdk-setup` without a subcommand automatically executes the setup process.
 
+## Flags
+
+| Flag        | Description                               |
+| ----------- | ----------------------------------------- |
+| `--dry-run` | Simulate actions without writing files    |
+| `--verbose` | Show detailed logs                        |
+| `--json`    | Output results as JSON                    |
+| `--force`   | Overwrite existing files                  |
+| `--skip-*`  | Skip optional steps like forms or secrets |
+
+## Developer Commands
+
+Run these from the project root:
+
+```bash
+npm run lint
+npm run format
+npm test
+npm run docs
+```
+
 When installed globally the CLI will warn you if a newer version is available.
 You can also run `aem-sdk-setup update` to upgrade to the latest release.
 
-## Contribution
+## Testing
 
-1. Fork the repository and create your branch.
-2. Install dependencies with `npm install`.
-3. Run `npm run format:check` and `npm run lint` before submitting a pull request.
-4. Run `npm test`.
-
-## Publishing
-
-Releases are automated using [semantic-release](https://github.com/semantic-release/semantic-release).
-Whenever commits are pushed to `main`, the `Release` workflow creates a new GitHub
-release and publishes the package to npm.
-
-Ensure a `NPM_TOKEN` secret with publish rights is configured for the repository
-so the workflow can upload the package.
-
-## Tech Stack
-
-- Node.js and [oclif](https://oclif.io/) for the CLI framework
-- `fs-extra`, `glob` and `unzipper` for filesystem and archive operations
-- Jest for unit testing with coverage
-- ESLint and Prettier for code style
-- GitHub Actions for continuous integration with linting, formatting checks, tests and CodeQL analysis
-
-## Package Information
-
-- **Name:** `aem-sdk-setup`
-- **Version:** see [`package.json`](package.json) for the current release
-- **License:** Apache-2.0
-- **Runtime dependencies:** `@oclif/core`, `fs-extra`, `glob`, `unzipper`
-- **Dev dependencies:** `jest`, `eslint`, `prettier`, `@types/node`
-
-## Code Coverage
-
-The `node.yml` workflow runs `npm test -- --coverage --coverageReporters=text --coverageReporters=lcov` on every commit. The coverage
-results are printed in the console and uploaded to Codecov.
-
-To check coverage locally run:
+Run the full test suite with coverage:
 
 ```bash
-npm test -- --coverage --coverageReporters=text --coverageReporters=lcov
+npm test -- --coverage
 ```
 
-The current test suite reports around **97%** statement coverage.
-
-## Code Quality
-
-In addition to coverage reports, the repository runs a scheduled CodeQL scan via
-GitHub Actions to detect common vulnerabilities and ensure code quality.
-
-## License Scan
-
-A dedicated workflow uses `license-checker` to review dependency licenses on
-every push and pull request. The generated report is uploaded as a workflow
-artifact for further inspection.
-
-## Security Audit
-
-An additional job runs `npm audit --audit-level=high` on each commit to detect
-known vulnerabilities in dependencies.
-
-## Supported Environments
-
-- Node.js 18 and later
-- Tested on Linux, macOS and Windows via GitHub Actions
+Tests mock all file and network operations using Jest.
 
 ## Documentation
 
-API documentation is generated with JSDoc and published in the [docs](docs/index.html) directory.
+Generate API reference using JSDoc:
+
+```bash
+npm run docs
+```
+
+Documentation is output to [docs/index.html](docs/index.html).
+
+## Release
+
+This project uses semantic-release to publish new versions and changelogs automatically when commits follow the Conventional Commits spec.
+
+## Contribution
+
+Use semantic commit messages and read [AGENTS.md](AGENTS.md) for full contributor rules.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following commands and options are available:
 | `aem-sdk-setup --version, -v`    | Display version number only          |
 | `aem-sdk-setup -d /path/to/zips` | Use files from a different directory |
 | `aem-sdk-setup -o ./result`      | Write instance to a custom folder    |
+| `aem-sdk-setup --verbose`        | Show detailed progress output        |
 | `aem-sdk-setup init`             | Create the default folder structure  |
 | `aem-sdk-setup autocomplete`     | Enable shell autocompletion          |
 | `aem-sdk-setup commands`         | List all available commands          |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AEM SDK Setup CLI
 
 [![CI](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/node.yml)
+[![npm](https://img.shields.io/npm/v/aem-sdk-setup.svg)](https://www.npmjs.com/package/aem-sdk-setup)
 [![Coverage Status](https://codecov.io/gh/AEM-X/aem-sdk-setup/branch/main/graph/badge.svg)](https://codecov.io/gh/AEM-X/aem-sdk-setup)
 [![CodeQL](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/codeql.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/codeql.yml)
 [![License Scan](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml/badge.svg)](https://github.com/AEM-X/aem-sdk-setup/actions/workflows/license.yml)
@@ -97,16 +98,19 @@ aem-sdk-setup --directory /path/to/zips --output ./result
 
 The following commands and options are available:
 
-```bash
-aem-sdk-setup --help, -h               # display usage information
-aem-sdk-setup --version, -v            # display version number only
-aem-sdk-setup -d /path/to/zips         # use files from a different directory
-aem-sdk-setup -o ./result              # write instance to a custom folder
-aem-sdk-setup init                     # create the default folder structure
-aem-sdk-setup autocomplete             # enable shell autocompletion
-aem-sdk-setup commands                 # list all available commands
-aem-sdk-setup update                   # update to the latest version
-```
+| Command                          | Description                          |
+| -------------------------------- | ------------------------------------ |
+| `aem-sdk-setup --help, -h`       | Display usage information            |
+| `aem-sdk-setup --version, -v`    | Display version number only          |
+| `aem-sdk-setup -d /path/to/zips` | Use files from a different directory |
+| `aem-sdk-setup -o ./result`      | Write instance to a custom folder    |
+| `aem-sdk-setup init`             | Create the default folder structure  |
+| `aem-sdk-setup autocomplete`     | Enable shell autocompletion          |
+| `aem-sdk-setup commands`         | List all available commands          |
+| `aem-sdk-setup update`           | Update to the latest version         |
+
+Flags such as `--dry-run` and `--verbose` can be used with most commands for
+additional control.
 
 Running `aem-sdk-setup` without a subcommand automatically executes the setup process.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ known vulnerabilities in dependencies.
 - Node.js 18 and later
 - Tested on Linux, macOS and Windows via GitHub Actions
 
+## Documentation
+
+API documentation is generated with JSDoc and published in the [docs](docs/index.html) directory.
+
 ## License
 
 This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/jsdoc.config.json
+++ b/jsdoc.config.json
@@ -1,0 +1,13 @@
+{
+  "source": {
+    "include": ["src"],
+    "exclude": ["node_modules"],
+    "includePattern": ".js$"
+  },
+  "opts": {
+    "destination": "./docs",
+    "recurse": true,
+    "template": "default"
+  },
+  "plugins": ["plugins/markdown"]
+}

--- a/oclif.config.json
+++ b/oclif.config.json
@@ -1,6 +1,6 @@
 {
   "name": "aem-sdk-setup",
-  "version": "1.0.0",
+  "version": "0.0.0-semantic-release",
   "bin": "aem-sdk-setup",
   "oclif": {
     "commands": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@oclif/plugin-update": "^4",
         "@oclif/plugin-version": "^2",
         "@oclif/plugin-warn-if-update-available": "^3",
+        "chalk": "^4.1.2",
         "extract-zip": "^2.0.1",
         "fs-extra": "^11.3.0",
         "glob": "^11.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-prettier": "^5.4.1",
         "jest": "^30.0.0",
+        "jsdoc": "^4.0.2",
         "prettier": "^3.5.3",
         "semantic-release": "^24.2.5",
         "ts-node": "^10.9.2"
@@ -2103,6 +2104,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.9.tgz",
+      "integrity": "sha512-yYxMVH7Dqw6nO0d5NIV8OQWnitU8k6vXH8NtgqAfIa/IUqRMxRv/NUJJ08VEKbAakwxlgBl5PJdrU0dMPStsnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.11.tgz",
@@ -3097,6 +3111,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -4041,6 +4080,19 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -4854,6 +4906,19 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-ci": {
@@ -8365,11 +8430,74 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
       "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
       "license": "MIT"
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.4.tgz",
+      "integrity": "sha512-zeFezwyXeG4syyYHbvh1A967IAqq/67yXtXvuL5wnqCkFZe8I0vKfm+EO+YEvLguo6w9CDUbrAXVtJSHh2E8rw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jsdoc/node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -8451,6 +8579,16 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -8493,6 +8631,16 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -8671,6 +8819,35 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "dev": true,
+      "license": "Unlicense",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
     "node_modules/marked": {
       "version": "15.0.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
@@ -8734,6 +8911,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/meow": {
       "version": "13.2.0",
@@ -8861,6 +9045,19 @@
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mkdirp-classic": {
@@ -12518,6 +12715,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -12759,6 +12966,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/resolve-alpn": {
@@ -14091,6 +14308,13 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -14104,6 +14328,13 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.8.0",
@@ -14472,6 +14703,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "extract-zip": "^2.0.1",
     "fs-extra": "^11.3.0",
     "glob": "^11.0.2",
+    "chalk": "^4.1.2",
     "unzipper": "^0.12.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "format:check": "prettier --check --ignore-path .prettierignore \"**/*.{js,json,md}\"",
     "prepare": "node bin/run --help",
     "prepack": "npm run format",
-    "release": "semantic-release"
+    "release": "semantic-release",
+    "docs": "jsdoc -c jsdoc.config.json"
   },
   "keywords": [
     "aem",
@@ -67,6 +68,7 @@
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-prettier": "^5.4.1",
     "jest": "^30.0.0",
+    "jsdoc": "^4.0.2",
     "prettier": "^3.5.3",
     "semantic-release": "^24.2.5",
     "ts-node": "^10.9.2"

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -5,6 +5,7 @@ const log = require('../utils/log');
 
 /**
  * Initialize the default folder structure used by the setup command.
+ * @module commands/init
  */
 module.exports = class Init extends Command {
   static description = 'Create default setup directory structure';
@@ -15,6 +16,10 @@ module.exports = class Init extends Command {
     }),
   };
 
+  /**
+   * Execute the command.
+   * @returns {Promise<void>} resolves when folders are created
+   */
   async run() {
     const { args } = await this.parse(Init);
     const base = path.resolve(args.directory);

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
-const { Command, Args } = require('@oclif/core');
+const { Command, Args, Flags } = require('@oclif/core');
+const chalk = require('chalk');
 const log = require('../utils/log');
 
 /**
@@ -9,6 +10,14 @@ const log = require('../utils/log');
  */
 module.exports = class Init extends Command {
   static description = 'Create default setup directory structure';
+  static flags = {
+    verbose: Flags.boolean({
+      char: 'v',
+      description: 'Show additional output',
+      default: false,
+    }),
+  };
+  static examples = ['aem-sdk-setup init', 'aem-sdk-setup init custom'];
   static args = {
     directory: Args.string({
       description: 'Directory to create the setup structure in',
@@ -21,7 +30,8 @@ module.exports = class Init extends Command {
    * @returns {Promise<void>} resolves when folders are created
    */
   async run() {
-    const { args } = await this.parse(Init);
+    const { args, flags } = await this.parse(Init);
+    const verbose = flags.verbose;
     const base = path.resolve(args.directory);
     const inputDir = path.join(base, 'input');
     const installDir = path.join(inputDir, 'install');
@@ -31,8 +41,12 @@ module.exports = class Init extends Command {
     await fs.ensureDir(installDir);
     await fs.ensureDir(secretsDir);
 
-    this.log(log.info(`Created ${inputDir}`));
-    this.log(log.info('Place your AEM SDK files here.'));
+    if (verbose) {
+      this.log(log.info(`Created ${inputDir}`));
+      this.log(log.info(`Created ${installDir}`));
+      this.log(log.info(`Created ${secretsDir}`));
+    }
+    this.log(log.info(chalk.bold('Place your AEM SDK files here.')));
     this.log(log.info(`Output will be written to ${outputDir}`));
   }
 };

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -1,6 +1,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const { Command, Args } = require('@oclif/core');
+const log = require('../utils/log');
 
 /**
  * Initialize the default folder structure used by the setup command.
@@ -25,8 +26,8 @@ module.exports = class Init extends Command {
     await fs.ensureDir(installDir);
     await fs.ensureDir(secretsDir);
 
-    this.log(`Created ${inputDir}`);
-    this.log(`Place your AEM SDK files here.`);
-    this.log(`Output will be written to ${outputDir}`);
+    this.log(log.info(`Created ${inputDir}`));
+    this.log(log.info('Place your AEM SDK files here.'));
+    this.log(log.info(`Output will be written to ${outputDir}`));
   }
 };

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -9,6 +9,7 @@ const { installForms } = require('../lib/forms');
 const { installSecrets } = require('../lib/secrets');
 const { installDispatcher } = require('../lib/dispatcher');
 const { copyStartScripts } = require('../lib/scripts');
+const log = require('../utils/log');
 
 /**
  * Root command for setting up an AEM SDK environment.
@@ -230,7 +231,7 @@ module.exports = class Setup extends Command {
       ux.action.start('Copying helper scripts');
       await copyStartScripts(outputDir, authorJar, publishJar);
       ux.action.stop();
-      this.log('AEM setup completed successfully.');
+      this.log(log.info('AEM setup completed successfully.'));
     } catch (error) {
       this.error(error instanceof Error ? error.message : String(error));
     } finally {

--- a/src/commands/setup.js
+++ b/src/commands/setup.js
@@ -14,6 +14,7 @@ const log = require('../utils/log');
 /**
  * Root command for setting up an AEM SDK environment.
  * It extracts the SDK archives, installs optional components and copies helper scripts.
+ * @module commands/setup
  */
 module.exports = class Setup extends Command {
   static description = 'Set up AEM SDK environment';
@@ -30,6 +31,10 @@ module.exports = class Setup extends Command {
     }),
   };
 
+  /**
+   * Execute the setup workflow.
+   * @returns {Promise<void>} resolves when setup completes
+   */
   async run() {
     const { flags } = await this.parse(Setup);
     const targetDir = path.resolve(flags.directory);

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,0 +1,15 @@
+const AUTHOR_INSTALL = 'instance/author/crx-quickstart/install';
+const PUBLISH_INSTALL = 'instance/publish/crx-quickstart/install';
+const AUTHOR_CONF = 'instance/author/crx-quickstart/conf';
+const PUBLISH_CONF = 'instance/publish/crx-quickstart/conf';
+const AUTHOR_SECRETS = 'instance/author/crx-quickstart/secretsdir';
+const PUBLISH_SECRETS = 'instance/publish/crx-quickstart/secretsdir';
+
+module.exports = {
+  AUTHOR_INSTALL,
+  PUBLISH_INSTALL,
+  AUTHOR_CONF,
+  PUBLISH_CONF,
+  AUTHOR_SECRETS,
+  PUBLISH_SECRETS,
+};

--- a/src/lib/constants.js
+++ b/src/lib/constants.js
@@ -1,10 +1,22 @@
+/**
+ * Shared folder paths used across the CLI.
+ * @module lib/constants
+ */
+
+/** Author install directory. */
 const AUTHOR_INSTALL = 'instance/author/crx-quickstart/install';
+/** Publish install directory. */
 const PUBLISH_INSTALL = 'instance/publish/crx-quickstart/install';
+/** Author configuration directory. */
 const AUTHOR_CONF = 'instance/author/crx-quickstart/conf';
+/** Publish configuration directory. */
 const PUBLISH_CONF = 'instance/publish/crx-quickstart/conf';
+/** Author secrets directory. */
 const AUTHOR_SECRETS = 'instance/author/crx-quickstart/secretsdir';
+/** Publish secrets directory. */
 const PUBLISH_SECRETS = 'instance/publish/crx-quickstart/secretsdir';
 
+/** Exported constant paths. */
 module.exports = {
   AUTHOR_INSTALL,
   PUBLISH_INSTALL,

--- a/src/lib/dispatcher.js
+++ b/src/lib/dispatcher.js
@@ -1,3 +1,7 @@
+/**
+ * Utilities for installing AEM Dispatcher configuration.
+ * @module lib/dispatcher
+ */
 const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');

--- a/src/lib/extraction.js
+++ b/src/lib/extraction.js
@@ -1,3 +1,7 @@
+/**
+ * Archive extraction utilities.
+ * @module lib/extraction
+ */
 const fs = require('fs-extra');
 const unzipper = require('unzipper');
 

--- a/src/lib/forms.js
+++ b/src/lib/forms.js
@@ -2,9 +2,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');
 const { extractZip } = require('./extraction');
-
-const AUTHOR_INSTALL = 'instance/author/crx-quickstart/install';
-const PUBLISH_INSTALL = 'instance/publish/crx-quickstart/install';
+const { AUTHOR_INSTALL, PUBLISH_INSTALL } = require('./constants');
 
 /**
  * Install the AEM Forms add-on from a ZIP file.

--- a/src/lib/forms.js
+++ b/src/lib/forms.js
@@ -1,3 +1,7 @@
+/**
+ * Utilities for installing the AEM Forms add-on.
+ * @module lib/forms
+ */
 const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');

--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -1,3 +1,7 @@
+/**
+ * Utilities for managing instance start scripts.
+ * @module lib/scripts
+ */
 const fs = require('fs-extra');
 const path = require('path');
 

--- a/src/lib/secrets.js
+++ b/src/lib/secrets.js
@@ -22,8 +22,10 @@ async function installSecrets(outputDir = '.') {
     path.join(outputDir, PUBLISH_CONF, 'sling.properties'),
     'org.apache.felix.configadmin.plugin.interpolation.secretsdir=${sling.home}/secretsdir',
   );
-  if (!(await fs.pathExists('secretsdir')))
+  const secretsDirExists = await fs.pathExists('secretsdir');
+  if (!secretsDirExists) {
     throw new Error('secretsdir directory not found');
+  }
 
   await fs.copy('secretsdir', path.join(outputDir, AUTHOR_SECRETS));
   await fs.copy('secretsdir', path.join(outputDir, PUBLISH_SECRETS));

--- a/src/lib/secrets.js
+++ b/src/lib/secrets.js
@@ -1,10 +1,12 @@
 const fs = require('fs-extra');
 const path = require('path');
 
-const AUTHOR_CONF = 'instance/author/crx-quickstart/conf';
-const PUBLISH_CONF = 'instance/publish/crx-quickstart/conf';
-const AUTHOR_SECRETS = 'instance/author/crx-quickstart/secretsdir';
-const PUBLISH_SECRETS = 'instance/publish/crx-quickstart/secretsdir';
+const {
+  AUTHOR_CONF,
+  PUBLISH_CONF,
+  AUTHOR_SECRETS,
+  PUBLISH_SECRETS,
+} = require('./constants');
 
 /**
  * Install secrets configuration and copy secretsdir if present.

--- a/src/lib/secrets.js
+++ b/src/lib/secrets.js
@@ -1,3 +1,7 @@
+/**
+ * Utilities for installing secrets configuration.
+ * @module lib/secrets
+ */
 const fs = require('fs-extra');
 const path = require('path');
 

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,7 +1,20 @@
+/**
+ * Utility to prefix log messages for consistent CLI output.
+ * @module utils/log
+ */
+
+/**
+ * Prefix log messages for consistent CLI output.
+ *
+ * @param {string} level log level label
+ * @param {string} msg message to display
+ * @returns {string} formatted log message
+ */
 function format(level, msg) {
   return `aem-sdk-setup: [${level}] ${msg}`;
 }
 
+/** Logging helpers used by commands. */
 module.exports = {
   info: (msg) => format('INFO', msg),
   warn: (msg) => format('WARN', msg),

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -1,0 +1,9 @@
+function format(level, msg) {
+  return `aem-sdk-setup: [${level}] ${msg}`;
+}
+
+module.exports = {
+  info: (msg) => format('INFO', msg),
+  warn: (msg) => format('WARN', msg),
+  error: (msg) => format('ERROR', msg),
+};

--- a/src/utils/log.js
+++ b/src/utils/log.js
@@ -10,8 +10,16 @@
  * @param {string} msg message to display
  * @returns {string} formatted log message
  */
+const chalk = require('chalk');
+
 function format(level, msg) {
-  return `aem-sdk-setup: [${level}] ${msg}`;
+  const colors = {
+    INFO: chalk.cyan,
+    WARN: chalk.yellow,
+    ERROR: chalk.red,
+  };
+  const color = colors[level] || ((t) => t);
+  return `aem-sdk-setup: ${color(`[${level}]`)} ${msg}`;
 }
 
 /** Logging helpers used by commands. */

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -3,9 +3,9 @@ const fs = require('fs-extra');
 
 jest.mock('fs-extra');
 
-const Init = require('../src/commands/init');
+const Init = require('../../src/commands/init');
 
-const ROOT_OPTS = { root: path.join(__dirname, '..') };
+const ROOT_OPTS = { root: path.join(__dirname, '..', '..') };
 
 afterEach(() => jest.resetAllMocks());
 

--- a/test/commands/init.test.js
+++ b/test/commands/init.test.js
@@ -11,7 +11,7 @@ afterEach(() => jest.resetAllMocks());
 
 test('creates default structure', async () => {
   const log = jest.spyOn(Init.prototype, 'log').mockImplementation();
-  await Init.run([], ROOT_OPTS);
+  await Init.run(['--verbose'], ROOT_OPTS);
   expect(fs.ensureDir).toHaveBeenCalledWith(
     path.join(process.cwd(), 'setup/input/install'),
   );
@@ -19,22 +19,23 @@ test('creates default structure', async () => {
     path.join(process.cwd(), 'setup/input/secretsdir'),
   );
   expect(log).toHaveBeenCalledWith(
-    `aem-sdk-setup: [INFO] Created ${path.join(process.cwd(), 'setup/input')}`,
+    expect.stringContaining(
+      `[INFO] Created ${path.join(process.cwd(), 'setup/input')}`,
+    ),
   );
   expect(log).toHaveBeenCalledWith(
-    'aem-sdk-setup: [INFO] Place your AEM SDK files here.',
+    expect.stringContaining('[INFO] Place your AEM SDK files here.'),
   );
   expect(log).toHaveBeenCalledWith(
-    `aem-sdk-setup: [INFO] Output will be written to ${path.join(
-      process.cwd(),
-      'setup/output',
-    )}`,
+    expect.stringContaining(
+      `Output will be written to ${path.join(process.cwd(), 'setup/output')}`,
+    ),
   );
 });
 
 test('accepts custom directory', async () => {
   const log = jest.spyOn(Init.prototype, 'log').mockImplementation();
-  await Init.run(['custom'], ROOT_OPTS);
+  await Init.run(['custom', '--verbose'], ROOT_OPTS);
   expect(fs.ensureDir).toHaveBeenCalledWith(
     path.join(process.cwd(), 'custom/input/install'),
   );
@@ -42,6 +43,8 @@ test('accepts custom directory', async () => {
     path.join(process.cwd(), 'custom/input/secretsdir'),
   );
   expect(log).toHaveBeenCalledWith(
-    `aem-sdk-setup: [INFO] Created ${path.join(process.cwd(), 'custom/input')}`,
+    expect.stringContaining(
+      `[INFO] Created ${path.join(process.cwd(), 'custom/input')}`,
+    ),
   );
 });

--- a/test/commands/setup.test.js
+++ b/test/commands/setup.test.js
@@ -4,25 +4,25 @@ const glob = require('glob');
 
 jest.mock('fs-extra');
 jest.mock('glob');
-jest.mock('../src/lib/extraction', () => ({
+jest.mock('../../src/lib/extraction', () => ({
   extractZip: jest.fn(() => Promise.resolve()),
 }));
-jest.mock('../src/lib/forms', () => ({
+jest.mock('../../src/lib/forms', () => ({
   installForms: jest.fn(() => Promise.resolve()),
 }));
-jest.mock('../src/lib/secrets', () => ({
+jest.mock('../../src/lib/secrets', () => ({
   installSecrets: jest.fn(() => Promise.resolve()),
 }));
-jest.mock('../src/lib/dispatcher', () => ({
+jest.mock('../../src/lib/dispatcher', () => ({
   installDispatcher: jest.fn(() => Promise.resolve()),
 }));
-jest.mock('../src/lib/scripts', () => ({
+jest.mock('../../src/lib/scripts', () => ({
   copyStartScripts: jest.fn(() => Promise.resolve()),
 }));
 
-const Setup = require('../src/commands/setup');
+const Setup = require('../../src/commands/setup');
 
-const ROOT_OPTS = { root: path.join(__dirname, '..') };
+const ROOT_OPTS = { root: path.join(__dirname, '..', '..') };
 
 describe('setup command', () => {
   const fsReal = require('fs');
@@ -116,7 +116,7 @@ describe('setup command', () => {
       question: jest.fn().mockResolvedValue('yes'),
       close: jest.fn(),
     });
-    const { copyStartScripts } = require('../src/lib/scripts');
+    const { copyStartScripts } = require('../../src/lib/scripts');
     await Setup.run([], ROOT_OPTS);
     expect(fs.remove).toHaveBeenCalledWith(
       path.join(path.resolve('setup/input'), 'aem-sdk'),
@@ -147,7 +147,7 @@ describe('setup command', () => {
         .mockResolvedValue('no'),
       close: jest.fn(),
     });
-    const { installSecrets } = require('../src/lib/secrets');
+    const { installSecrets } = require('../../src/lib/secrets');
     installSecrets.mockRejectedValue(new Error('fail'));
     await expect(Setup.run([], ROOT_OPTS)).rejects.toThrow('fail');
   });
@@ -189,7 +189,7 @@ describe('setup command', () => {
         .mockResolvedValue('no'), // continue on failure
       close: jest.fn(),
     });
-    const { installDispatcher } = require('../src/lib/dispatcher');
+    const { installDispatcher } = require('../../src/lib/dispatcher');
     installDispatcher.mockRejectedValue(new Error('dispfail'));
     await expect(Setup.run([], ROOT_OPTS)).rejects.toThrow('dispfail');
   });
@@ -209,7 +209,7 @@ describe('setup command', () => {
       close: jest.fn(),
     });
     const warn = jest.spyOn(Setup.prototype, 'warn');
-    const { installSecrets } = require('../src/lib/secrets');
+    const { installSecrets } = require('../../src/lib/secrets');
     installSecrets.mockRejectedValue(new Error('oops'));
     await Setup.run([], ROOT_OPTS);
     expect(warn).toHaveBeenCalledWith(
@@ -232,7 +232,7 @@ describe('setup command', () => {
       close: jest.fn(),
     });
     const warn = jest.spyOn(Setup.prototype, 'warn');
-    const { installDispatcher } = require('../src/lib/dispatcher');
+    const { installDispatcher } = require('../../src/lib/dispatcher');
     installDispatcher.mockRejectedValue(new Error('oops'));
     await Setup.run([], ROOT_OPTS);
     expect(warn).toHaveBeenCalledWith(

--- a/test/commands/setup.test.js
+++ b/test/commands/setup.test.js
@@ -257,4 +257,34 @@ describe('setup command', () => {
     });
     await Setup.run([], ROOT_OPTS);
   });
+
+  test('prints verbose details when flag set', async () => {
+    glob.sync
+      .mockReturnValueOnce(['aem-sdk.zip'])
+      .mockReturnValueOnce(['aem-sdk-quickstart-1.jar'])
+      .mockReturnValueOnce([]);
+    fs.pathExists
+      .mockResolvedValueOnce(true) // target dir
+      .mockResolvedValueOnce(false); // install folder
+    fs.ensureDir.mockResolvedValue();
+    fs.copy.mockResolvedValue();
+    jest
+      .spyOn(require('node:readline/promises'), 'createInterface')
+      .mockReturnValue({
+        question: jest.fn().mockResolvedValue('no'),
+        close: jest.fn(),
+      });
+    const log = jest.spyOn(Setup.prototype, 'log').mockImplementation();
+    await Setup.run(['--verbose'], ROOT_OPTS);
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Using input directory ${path.resolve('setup/input')}`,
+      ),
+    );
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `Writing output to ${path.resolve('setup/input', '../output')}`,
+      ),
+    );
+  });
 });

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -19,11 +19,16 @@ test('creates default structure', async () => {
     path.join(process.cwd(), 'setup/input/secretsdir'),
   );
   expect(log).toHaveBeenCalledWith(
-    `Created ${path.join(process.cwd(), 'setup/input')}`,
+    `aem-sdk-setup: [INFO] Created ${path.join(process.cwd(), 'setup/input')}`,
   );
-  expect(log).toHaveBeenCalledWith('Place your AEM SDK files here.');
   expect(log).toHaveBeenCalledWith(
-    `Output will be written to ${path.join(process.cwd(), 'setup/output')}`,
+    'aem-sdk-setup: [INFO] Place your AEM SDK files here.',
+  );
+  expect(log).toHaveBeenCalledWith(
+    `aem-sdk-setup: [INFO] Output will be written to ${path.join(
+      process.cwd(),
+      'setup/output',
+    )}`,
   );
 });
 
@@ -37,6 +42,6 @@ test('accepts custom directory', async () => {
     path.join(process.cwd(), 'custom/input/secretsdir'),
   );
   expect(log).toHaveBeenCalledWith(
-    `Created ${path.join(process.cwd(), 'custom/input')}`,
+    `aem-sdk-setup: [INFO] Created ${path.join(process.cwd(), 'custom/input')}`,
   );
 });

--- a/test/lib/constants.test.js
+++ b/test/lib/constants.test.js
@@ -1,0 +1,6 @@
+const c = require('../../src/lib/constants');
+
+test('exports paths', () => {
+  expect(c.AUTHOR_INSTALL).toBe('instance/author/crx-quickstart/install');
+  expect(c.PUBLISH_SECRETS).toBe('instance/publish/crx-quickstart/secretsdir');
+});

--- a/test/lib/log.test.js
+++ b/test/lib/log.test.js
@@ -1,13 +1,13 @@
 const log = require('../../src/utils/log');
 
 test('prefixes info messages', () => {
-  expect(log.info('test')).toBe('aem-sdk-setup: [INFO] test');
+  expect(log.info('test')).toContain('[INFO] test');
 });
 
 test('prefixes warnings', () => {
-  expect(log.warn('warn')).toBe('aem-sdk-setup: [WARN] warn');
+  expect(log.warn('warn')).toContain('[WARN] warn');
 });
 
 test('prefixes errors', () => {
-  expect(log.error('boom')).toBe('aem-sdk-setup: [ERROR] boom');
+  expect(log.error('boom')).toContain('[ERROR] boom');
 });

--- a/test/lib/log.test.js
+++ b/test/lib/log.test.js
@@ -1,0 +1,9 @@
+const log = require('../../src/utils/log');
+
+test('prefixes info messages', () => {
+  expect(log.info('test')).toBe('aem-sdk-setup: [INFO] test');
+});
+
+test('prefixes warnings', () => {
+  expect(log.warn('warn')).toBe('aem-sdk-setup: [WARN] warn');
+});

--- a/test/lib/log.test.js
+++ b/test/lib/log.test.js
@@ -7,3 +7,7 @@ test('prefixes info messages', () => {
 test('prefixes warnings', () => {
   expect(log.warn('warn')).toBe('aem-sdk-setup: [WARN] warn');
 });
+
+test('prefixes errors', () => {
+  expect(log.error('boom')).toBe('aem-sdk-setup: [ERROR] boom');
+});


### PR DESCRIPTION
## Summary
- centralize important path strings in `constants.js`
- introduce `utils/log.js` for prefixed CLI messages
- update commands to use centralized logging
- document flags in README and add npm badge
- add repository guidelines in `AGENTS.md`
- cover new modules with unit tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798c6dc04c832f89c1ce399ed5074a